### PR TITLE
Deal with no colorcolumn settings

### DIFF
--- a/lua/virt-column/init.lua
+++ b/lua/virt-column/init.lua
@@ -44,7 +44,12 @@ M.refresh = function()
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     local width = vim.api.nvim_win_get_width(winnr) - ffi.C.curwin_col_off()
     local textwidth = vim.opt.textwidth:get()
-    local colorcolumn = { unpack(vim.opt.colorcolumn:get()), unpack(vim.split(M.config.virtcolumn, ",")) }
+    local colorcolumn = vim.opt.colorcolumn:get()
+    if M.config.virtcolumn ~= "" then
+      for _, v in ipairs(vim.split(M.config.virtcolumn, ",")) do
+        table.insert(colorcolumn, v)
+      end
+    end
 
     for i, c in ipairs(colorcolumn) do
         if vim.startswith(c, "+") then


### PR DESCRIPTION
When `colorcolumn` is not set, `colorcolumn` (local variable) should
become `{ [2] = "" }` and an error occurs as below.

<details><summary>the error</summary>

```
E5108: Error executing lua ...packer/opt/virt-column.nvim/lua/virt-column/commands.lua:12: Vim(lua):E5108: Error executing lua ...ack/packer/opt/virt-column.nvim/lua/virt-column/
init.lua:60: attempt to compare nil with string
stack traceback:
        ...ack/packer/opt/virt-column.nvim/lua/virt-column/init.lua:60: in function <...ack/packer/opt/virt-column.nvim/lua/virt-column/init.lua:59>
        [C]: in function 'sort'
        ...ack/packer/opt/virt-column.nvim/lua/virt-column/init.lua:59: in function 'refresh'
        [string ":lua"]:1: in main chunk
        [C]: in function 'cmd'
        ...packer/opt/virt-column.nvim/lua/virt-column/commands.lua:12: in function 'refresh
        [string ":lua"]:1: in main chunk
stack traceback:
        [C]: in function 'cmd'
        ...packer/opt/virt-column.nvim/lua/virt-column/commands.lua:12: in function 'refresh'
  '      [string ":lua"]:1: in main chunk
```
</details>

This fixes it.