### PR TITLE
Use default link for highlight

### DIFF
--- a/lua/virt-column/init.lua
+++ b/lua/virt-column/init.lua
@@ -22,7 +22,7 @@ M.setup = function(config)
     M.namespace = vim.api.nvim_create_namespace "virt-column"
 
     vim.cmd [[command! -bang VirtColumnRefresh lua require("virt-column.commands").refresh("<bang>" == "!")]]
-    vim.cmd [[highlight link VirtColumn Whitespace]]
+    vim.cmd [[highlight default link VirtColumn Whitespace]]
     vim.cmd [[highlight clear ColorColumn]]
 
     vim.cmd [[


### PR DESCRIPTION
Using a regular link means that the highlight will be cleared when users set their colorscheme.

Using a default link will allow it to survive `:colo`, and also allow it to be overriden by the user manually linking/defining the highlight group.