### PR TITLE
fix: calculate valid widths by virtcol()

### DIFF
--- a/lua/virt-column/init.lua
+++ b/lua/virt-column/init.lua
@@ -46,7 +46,6 @@ M.refresh = function()
     end
 
     local config = vim.tbl_deep_extend("force", M.config, M.buffer_config[bufnr] or {})
-    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     local textwidth = vim.opt.textwidth:get()
     local colorcolumn = utils.concat_table(vim.opt.colorcolumn:get(), vim.split(config.virtcolumn, ","))
 
@@ -74,10 +73,10 @@ M.refresh = function()
 
     M.clear_buf(bufnr)
 
-    for i = 1, #lines, 1 do
+    for i = 1, vim.fn.line "$", 1 do
         for _, column in ipairs(colorcolumn) do
-            local line = lines[i]:gsub("\t", string.rep(" ", vim.opt.tabstop:get()))
-            if vim.api.nvim_strwidth(line) < column then
+            local width = vim.fn.virtcol { i, "$" } - 1
+            if width < column then
                 vim.api.nvim_buf_set_extmark(bufnr, M.namespace, i - 1, 0, {
                     virt_text = { { config.char, "VirtColumn" } },
                     virt_text_pos = "overlay",

--- a/lua/virt-column/init.lua
+++ b/lua/virt-column/init.lua
@@ -73,7 +73,7 @@ M.refresh = function()
 
     M.clear_buf(bufnr)
 
-    for i = 1, vim.fn.line "$", 1 do
+    for i = 1, vim.api.nvim_buf_line_count(bufnr), 1 do
         for _, column in ipairs(colorcolumn) do
             local width = vim.fn.virtcol { i, "$" } - 1
             if width < column then


### PR DESCRIPTION
This fixes 2 problems.

## 1. consider Tab's validly

The current build calculates line widths with replacing Tab `\t` into `'tabstop'` count of spaces.

https://github.com/lukas-reineke/virt-column.nvim/blob/93b40ea038f676f5a72d7d1f2336fe7b051fc0ce/lua/virt-column/init.lua#L79-L80

We gets wrong widths by this logic. This is because the logic always calculates the width of `\t` into the `'tabtop'` value. I fixed this by using `virtcol()`.

```vim
" Below shows tab string by >------- string
" set tabstop=8
foo_bars>-------foo  " --> it calculates the width: 19 -- This is correct.
foo_bar_foo>----foo  " --> it calculates the width: 22 -- This is wrong! The correct value is 19.
```

## 2. consider inline virtual texts

Now Neovim has [inline virtual texts][1] and it can insert texts between chars in lines. This problem is also solved by `virtcol()`.

[1]: https://github.com/neovim/neovim/pull/20130

FYI: With such inline texts, `'cursorcolumn'` itself does not move. See discussions in https://github.com/neovim/neovim/pull/24090.
