### PR TITLE
Replace deprecated API 

### DIFF
--- a/lua/virt-column/utils.lua
+++ b/lua/virt-column/utils.lua
@@ -14,7 +14,7 @@ end
 ---@return T
 M.tbl_join = function(...)
     local result = {}
-    for i, v in ipairs(vim.tbl_flatten { ... }) do
+    for i, v in ipairs(vim.iter(...):flatten():totable()) do
         result[i] = v
     end
     return result


### PR DESCRIPTION
Since neovim v0.10 the API call [`vim.tbl_flatten { ... }`](https://github.com/neovim/neovim/blob/v0.10.0/runtime/lua/vim/shared.lua#L555) was deprecated. Instead `Iter.flatten` should be used. Initially the functionality should be removed with 0.12, but it was already set to 0.13 on neovim master so there is certainly still some time for changing this if you would rather provide downwards compatibility for now.