### PR TITLE
fix: replace deprecated vim.tbl_flatten with vim.iter

### DIFF
--- a/lua/virt-column/utils.lua
+++ b/lua/virt-column/utils.lua
@@ -13,7 +13,8 @@ end
 ---@vararg T
 ---@return T
 M.tbl_join = function(...)
-    return vim.iter({ ... }):flatten():totable()
+    ---@diagnostic disable-next-line: deprecated
+    return vim.iter and vim.iter({ ... }):flatten():totable() or vim.tbl_flatten { ... }
 end
 
 ---@generic T

--- a/lua/virt-column/utils.lua
+++ b/lua/virt-column/utils.lua
@@ -14,7 +14,7 @@ end
 ---@return T
 M.tbl_join = function(...)
     local result = {}
-    for i, v in ipairs(vim.tbl_flatten { ... }) do
+    for i, v in vim.iter({ ... }):flatten():enumerate() do
         result[i] = v
     end
     return result

--- a/lua/virt-column/utils.lua
+++ b/lua/virt-column/utils.lua
@@ -13,11 +13,7 @@ end
 ---@vararg T
 ---@return T
 M.tbl_join = function(...)
-    local result = {}
-    for i, v in vim.iter({ ... }):flatten():enumerate() do
-        result[i] = v
-    end
-    return result
+    return vim.iter({ ... }):flatten():totable()
 end
 
 ---@generic T


### PR DESCRIPTION
Supersedes #43, as #43 broke the column for me.

If backwards compatibility is a concern, I'd be happy to add a code path which feature detects `vim.iter`.