### PR TITLE
Autoload plugin and Vimscript config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use your favourite plugin manager to install.
 For [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
-{ "lukas-reineke/virt-column.nvim", opts = {} },
+{ "lukas-reineke/virt-column.nvim" },
 ```
 
 For [pckr.nvim](https://github.com/lewis6991/pckr.nvim):
@@ -22,13 +22,22 @@ use "lukas-reineke/virt-column.nvim"
 
 ## Setup
 
-To configure virt-column.nvim you need to run the setup function.
+To configure virt-column.nvim you can run the setup function or put
+configuration in `vim.g.virt_column` / `g:virt_column`. Running setup is not
+necessary with the default configuration.
 
 ```lua
-require("virt-column").setup()
+require("virt-column").setup({
+    -- your config here
+})
+-- or:
+vim.g.virt_column = {
+    -- your config here
+}
 ```
 
-Please see `:help virt-column.txt` for more details and all possible values.
+Please see [`:help virt-column.txt`](./doc/virt-column.txt) for more details
+and all possible values.
 
 ## Thanks
 

--- a/plugin/virt-column.lua
+++ b/plugin/virt-column.lua
@@ -1,0 +1,1 @@
+require("virt-column").setup(vim.g.virt_column)


### PR DESCRIPTION
- Configure using `vim.g.virt_column` allows for configuration in
  Vimscript
- `plugin/` autoloads this plugin, no need for the user to call `setup()`

This PR is fully backwards compatible. Users can choose to use `vim.g.virt_column = ...` or `require("virt-column").setup(...)`. I've currently only changed the documentation for this in the README, since the help page only describes the Lua API, so I didn't know if a description in the help doc was needed for this feature.

Thanks in advance for considering this PR!
